### PR TITLE
Gör det möjligt att logga in utan nxauth igen

### DIFF
--- a/helpers/nxauth.php
+++ b/helpers/nxauth.php
@@ -3,4 +3,7 @@ if(empty($global_root)) {
 	throw new Exception("\$global_root needs to be set");
 }
 require_once $global_root."/vendor/nitroxy/nxauth/include.php";
-NXAuth::init($settings['cas_config']);
+
+if($settings['primary_login_method'] == "nxauth") {
+	NXAuth::init($settings['cas_config']);
+}

--- a/libs/color_terminal.php
+++ b/libs/color_terminal.php
@@ -1,4 +1,4 @@
-<?
+<?php
 /**
  * Helper functions for outputing color in terminals
  */

--- a/migrations/update_database.php
+++ b/migrations/update_database.php
@@ -1,5 +1,5 @@
 #!/usr/bin/php
-<?
+<?php
 include dirname(__FILE__) . "/../includes.php";
 include "$repo_root/libs/color_terminal.php";
 
@@ -128,7 +128,7 @@ function run_migration($version, $filename) {
 	}
 }
 
-/** 
+/**
  * Returns true if the specified version is applied
  */
 function migration_applied($version) {

--- a/nitroxy_retail.sql
+++ b/nitroxy_retail.sql
@@ -254,7 +254,7 @@ DROP TABLE IF EXISTS `users`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `users` (
-  `user_id` int(10) unsigned NOT NULL,
+  `user_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `first_name` varchar(100) COLLATE utf8_swedish_ci NOT NULL,
   `surname` varchar(100) COLLATE utf8_swedish_ci NOT NULL,
   `username` varchar(100) COLLATE utf8_swedish_ci NOT NULL,

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,16 +1,16 @@
-### MAPPAR I PUBLIC SOM SKA GÅ ATT KOMMA ÅT
+### MAPPAR I PUBLIC SOM SKA GÃ… ATT KOMMA Ã…T
 
 RewriteCond %{REQUEST_URI} !^/gfx/.+
 RewriteCond %{REQUEST_URI} !^/scripts/.+
 RewriteCond %{REQUEST_URI} !^/js/.+
 
-### FILER I PUBLIC SOM SKA GÅ ATT KOMMA ÅT
+### FILER I PUBLIC SOM SKA GÃ… ATT KOMMA Ã…T
 
 RewriteCond %{REQUEST_URI} !^/index.php/
 RewriteCond %{REQUEST_URI} !^/style.css
 RewriteCond %{REQUEST_URI} !^/favicon
 
-### ÄNDRA INGET NEDANFÖR DENNA RAD
+### Ã„NDRA INGET NEDANFÃ–R DENNA RAD
 
 RewriteRule (.*) index.php/$1
 RewriteEngine On

--- a/public/index.php
+++ b/public/index.php
@@ -2,7 +2,7 @@
 require "../includes.php";
 
 // Prepare path
-$path_info=$_SERVER['PATH_INFO'];
+$path_info = isset($_SERVER['PATH_INFO']) ? $_SERVER['PATH_INFO'] : '';
 $untouched_request=$path_info;
 $request=explode('/',$path_info);
 array_shift($request);

--- a/views/Menu/index.php
+++ b/views/Menu/index.php
@@ -60,7 +60,7 @@
 				</div>
 			</form>
 		</li>
-	<?php else: ?>
+	<?php elseif ($settings['primary_login_method'] == "nxauth"): ?>
 		<li>
 			<a href="/Session/nx_login?kickback=<?=htmlspecialchars(kickback_url())?>">
 				Logga in
@@ -71,6 +71,11 @@
 				Lokal inloggning
 			</a>
 		</li>
+	<?php else: ?>
+		<li>
+			<a href="/Session/login?kickback=<?=htmlspecialchars(kickback_url())?>">
+				Logga in
+			</a>
+		</li>
 	<?php endif ?>
 </ul>
-


### PR DESCRIPTION
Sen 4d7a6444 (som jag inte ens vet om det körs på kioskdatorn än) så krävs nxauth, det tycker jag är annonying i en utvecklingsmiljö när koden har stöd för lokal inloggning (det är mest frustrerande för att det kräver att man har eller genererar en API nyckel). "Krävs" innebär att den ovillkorligt anropade `NXAuth::init` vilket kräver att du har en nyckel.

Detta fixar så man nu kan välja att köra bara lokal inloggning igen.

Sen är det lite småfixar som longtags, encoding osv.